### PR TITLE
Default to current working directory (so you can omit the -d option)

### DIFF
--- a/bin/mxunit-watch
+++ b/bin/mxunit-watch
@@ -25,8 +25,6 @@ program
 
 program.dir = program.dir || process.cwd() + "/";
 
-console.log(program.dir);
-
 // try to read JSON configuration in watch directory
 var configFilePath = program.dir + ".mxunit-watch";
 try {


### PR DESCRIPTION
This changes the default directory to the current working directory of the process rather than the directory where the mxunit-watch script lives
